### PR TITLE
Add cash options from 2500 to 10000

### DIFF
--- a/mods/raclassic/rules/player.yaml
+++ b/mods/raclassic/rules/player.yaml
@@ -37,6 +37,8 @@ Player:
 	PowerManager:
 	AllyRepair:
 	PlayerResources:
+		SelectableCash: 2500, 3000, 3500, 4000, 4500, 5000, 5500, 6000, 6500, 7000, 7500, 8000, 8500, 9000, 9500, 10000
+		DefaultCash: 10000
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
 	GpsWatcher:


### PR DESCRIPTION
Looks like original game had from 0 to 10000, maybe because no-base games was a thing. But i don't think anything below 2500 is necessary as PP + REF costs 2300.

That much selection looks a bit wierd with dropdown menu, i tryed adding a scroll bar to it but couldn't manage, i think editing C# code is required for that.