### PR TITLE
Remove Cash Ticks from Refinery and Crates

### DIFF
--- a/mods/raclassic/rules/misc.yaml
+++ b/mods/raclassic/rules/misc.yaml
@@ -20,7 +20,7 @@ CRATE:
 	GiveCashCrateAction:
 		Amount: 1000
 		SelectionShares: 50
-		UseCashTick: true
+		Effect: dollar
 	ExplodeCrateAction@fire:
 		Weapon: CrateNapalm
 		SelectionShares: 5
@@ -109,7 +109,7 @@ MONEYCRATE:
 	GiveCashCrateAction:
 		Amount: 500
 		SelectionShares: 1
-		UseCashTick: true
+		Effect: dollar
 	RenderSprites:
 		Image: wcrate
 

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -874,6 +874,7 @@ PROC:
 	Refinery:
 		DockAngle: 64
 		DockOffset: 1,2
+		ShowTicks: false
 	StoresResources:
 		PipCount: 17
 		Capacity: 2000


### PR DESCRIPTION
Looks like Sellable don't have a tag to set those, so it has so stay for it.