### PR TITLE
Make Thief buildable

### DIFF
--- a/mods/raclassic/rules/infantry.yaml
+++ b/mods/raclassic/rules/infantry.yaml
@@ -407,7 +407,7 @@ THF:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 110
-		Prerequisites: ~tent, atek, ~disabled, ~techlevel.8
+		Prerequisites: ~tent, atek, ~techlevel.8
 		Description: Steals enemy credits.\n  Unarmed
 	RevealsShroud:
 		Range: 5c0


### PR DESCRIPTION
I kept him unbuildable as it didn't work, but looks like FrameLimiter added it.